### PR TITLE
Display delta in net worth from last month

### DIFF
--- a/app/models/financial_datum.rb
+++ b/app/models/financial_datum.rb
@@ -27,7 +27,7 @@ class FinancialDatum < ApplicationRecord
       year: year,
       income: income,
       expenses: expenses,
-      net_worth: net_worth
+      net_worth: net_worth,
     )
   end
 
@@ -70,6 +70,12 @@ class FinancialDatum < ApplicationRecord
     net_worth / withdraw_rate_multiplier
   end
 
+  def net_worth_delta
+    if previous_datum
+      net_worth - previous_datum.net_worth
+    end
+  end
+
   def year_is_within_financial_history_range
     if year && year > current_year
       errors.add(:year, "cannot be in the future")
@@ -83,5 +89,19 @@ class FinancialDatum < ApplicationRecord
 
   def current_year
     Time.zone.now.year
+  end
+
+  def previous_datum
+    prev_month, prev_year = previous_date
+    FinancialDatum.find_by(user: user, month: prev_month, year: prev_year)
+  end
+
+  def previous_date
+    month_idx = FinancialDatum.months[month]
+    if january?
+      [11, year - 1]
+    else
+      [month_idx - 1, year]
+    end
   end
 end

--- a/app/views/financial_data/index.html.erb
+++ b/app/views/financial_data/index.html.erb
@@ -10,21 +10,23 @@ Financial Data Index
     <th>%FI</th>
     <th>SR</th>
     <th>4%SW</th>
+    <th>deltaNW</th>
   </thead>
-<% financial_data.each do |datum| %>
-  <tr id="financial-datum-row-<%= datum.id %>">
-    <td><%= datum.month %></td>
-    <td><%= datum.year %></td>
-    <td>$<%= datum.income %></td>
-    <td>$<%= datum.expenses %></td>
-    <td>$<%= datum.net_worth %></td>
-    <td><%= "%.2f" % datum.percent_fi %></td>
-    <td><%= "%.2f" % datum.savings_rate %></td>
-    <td>$<%= datum.safe_withdraw_amount %></td>
-    <td><%= link_to "Edit", edit_financial_datum_url(datum) %></td>
-    <td><%= link_to "Delete", financial_datum_url(datum), method: :delete %></td>
-  </tr>
-<% end %>
+  <% financial_data.each do |datum| %>
+    <tr id="financial-datum-row-<%= datum.id %>">
+      <td><%= datum.month %></td>
+      <td><%= datum.year %></td>
+      <td>$<%= datum.income %></td>
+      <td>$<%= datum.expenses %></td>
+      <td>$<%= datum.net_worth %></td>
+      <td><%= "%.2f" % datum.percent_fi %></td>
+      <td><%= "%.2f" % datum.savings_rate %></td>
+      <td>$<%= datum.safe_withdraw_amount %></td>
+      <td>$<%= datum.net_worth_delta %></td>
+      <td><%= link_to "Edit", edit_financial_datum_url(datum) %></td>
+      <td><%= link_to "Delete", financial_datum_url(datum), method: :delete %></td>
+    </tr>
+  <% end %>
 </table>
 
 <%= link_to "New Financial Data Entry", new_financial_datum_path %>

--- a/spec/models/financial_datum_spec.rb
+++ b/spec/models/financial_datum_spec.rb
@@ -123,4 +123,29 @@ RSpec.describe FinancialDatum, type: :model do
       expect(result).to eq expected_result
     end
   end
+
+  describe "#net_worth_delta" do
+    it "returns the delta in networth from last month" do
+      user = create(:user)
+      datum_one =
+        create(:financial_datum, user: user, month: "january", year: 2018)
+      datum_two =
+        create(:financial_datum, user: user, month: "february", year: 2018)
+      expected_result = datum_two.net_worth - datum_one.net_worth
+
+      result = datum_two.net_worth_delta
+
+      expect(result).to eq expected_result
+    end
+
+    context "there is no previous months datum" do
+      it "returns nil" do
+        datum = build_stubbed(:financial_datum)
+
+        result = datum.net_worth_delta
+
+        expect(result).to be_nil
+      end
+    end
+  end
 end

--- a/spec/views/financial_data/index.html.erb_spec.rb
+++ b/spec/views/financial_data/index.html.erb_spec.rb
@@ -28,6 +28,18 @@ RSpec.describe "financial_data/index.html.erb" do
       expect(rendered).to have_content("4%SW")
       expect(rendered).to have_content(datum.safe_withdraw_amount)
     end
+
+    it "renders the delta in net_worth from last month" do
+      datum_one = create(:financial_datum, month: "january", year: 2018)
+      datum_two = create(:financial_datum, month: "february", year: 2018)
+
+      render template: "financial_data/index.html.erb",
+             locals: { financial_data: [datum_one, datum_two] }
+
+      expect(rendered).to have_content("deltaNW")
+      expect(rendered).to have_content(datum_two.net_worth_delta)
+    end
+
   end
 end
 


### PR DESCRIPTION
Why:
On the financial data index page we would like a given datum to show the
change in net worth from the previous month. If a there is no datum for
the previous month, it will not display anything.

This commit:
Adds a deltaNW column to table on the index and a method on the
FinancialDatum model to find the previous months datum for the user and
calculate the change in networth.