### PR TITLE
Add time to fi to data summary

### DIFF
--- a/app/models/fi_calculator.rb
+++ b/app/models/fi_calculator.rb
@@ -1,0 +1,59 @@
+class FiCalculator
+  GROWTH_RATE = 0.07
+  INFLATION_RATE = 0.02
+  RAISE_RATE = 0.05
+  WITHDRAW_RATE = 0.04
+
+  def initialize(net_worth:, expenses:, income:)
+    @net_worth = net_worth
+    @expenses = expenses
+    @income = income
+    @calc_percent_fi = 0.0
+    @calc_income = income
+    @calc_expenses = expenses
+    @calc_net_worth = net_worth
+  end
+
+  def time_to_fi
+    @months_to_fi = 0
+    @calc_percent_fi = fi_percent
+    while @calc_percent_fi < 1.0
+      @months_to_fi += 1
+
+      @calc_expenses = apply_rate(@calc_expenses, (INFLATION_RATE / 12))
+
+      if (@months_to_fi % 12).zero?
+        @calc_income = apply_rate(@calc_income, RAISE_RATE)
+      end
+
+      new_net_worth = (@calc_net_worth + @calc_income - @calc_expenses)
+      @calc_net_worth = apply_rate(new_net_worth, (GROWTH_RATE / 12))
+
+      @calc_percent_fi = fi_percent
+      break if @months_to_fi >= 1200
+    end
+
+    @months_to_fi
+  end
+
+  private
+
+  def fi_percent
+    @calc_net_worth / ((12 / WITHDRAW_RATE) * @calc_expenses)
+  end
+
+  def apply_rate(value, rate)
+    value * (1 + rate)
+  end
+
+  def print_data_point
+    <<~FI_DATA
+      ----
+      months:         #{@months_to_fi}
+      percent_fi:     #{@calc_percent_fi}
+      calc_income:    #{@calc_income}
+      calc_expenses:  #{@calc_expenses}
+      calc_net_worth: #{@calc_net_worth}
+    FI_DATA
+  end
+end

--- a/app/models/financial_data_summary.rb
+++ b/app/models/financial_data_summary.rb
@@ -32,7 +32,11 @@ class FinancialDataSummary
   end
 
   def time_to_fi
-    last_datum_query.first.time_to_fi
+    FiCalculator.new(
+      net_worth: net_worth,
+      income: average_income,
+      expenses: average_expenses,
+    ).time_to_fi
   end
 
   private

--- a/app/views/financial_data/_summary.html.erb
+++ b/app/views/financial_data/_summary.html.erb
@@ -6,12 +6,16 @@
       <th>AveIncome</th>
       <th>AveExpenses</th>
       <th>%FI</th>
+      <th>TimeToFI</th>
+      <th>Date Of FI</th>
     </thead>
     <tr>
       <td>$<%= data_summary.net_worth %></td>
-      <td>$<%= data_summary.average_expenses %></td>
       <td>$<%= data_summary.average_income %></td>
+      <td>$<%= data_summary.average_expenses %></td>
       <td><%= "%.2f" % data_summary.percent_fi %></td>
+      <td><%= data_summary.time_to_fi / 12 %> years <%= (data_summary.time_to_fi % 12) %> months</td>
+      <td><%= data_summary.time_to_fi.months.from_now.strftime("%b %Y") %></td>
     </tr>
   </table>
 </div>

--- a/spec/models/fi_calculator_spec.rb
+++ b/spec/models/fi_calculator_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe "FiCalculator" do
+  describe ".time_to_fi" do
+    context "it is possible to reach fi" do
+      it "returns the time to fi in months" do
+        expenses_one = 100
+        income_one = 10000
+        net_worth_one = 0
+
+        expenses_two = 1000
+        income_two = 10000
+        net_worth_two = 0
+
+        expenses_three = 2000
+        income_three = 2100
+        net_worth_three = 100000
+
+        result_one = FiCalculator.new(
+          net_worth: net_worth_one,
+          expenses: expenses_one,
+          income: income_one,
+        ).time_to_fi
+
+        result_two = FiCalculator.new(
+          net_worth: net_worth_two,
+          expenses: expenses_two,
+          income: income_two,
+        ).time_to_fi
+
+        result_three = FiCalculator.new(
+          net_worth: net_worth_three,
+          expenses: expenses_three,
+          income: income_three,
+        ).time_to_fi
+
+        expect(result_one).to eq 4
+        expect(result_two).to eq 31
+        expect(result_three).to eq 255
+      end
+    end
+
+    context "fi has already been reached" do
+      it "returns 0" do
+        expenses = 100
+        income = 0
+        net_worth = 100000
+
+        result = FiCalculator.new(
+          net_worth: net_worth,
+          expenses: expenses,
+          income: income,
+        ).time_to_fi
+
+        expect(result).to eq 0
+      end
+    end
+
+    context "fi can never be reached" do
+      it "returns 1200" do
+        expenses = 1000
+        income = 100
+        net_worth = 0
+
+        result = FiCalculator.new(
+          net_worth: net_worth,
+          expenses: expenses,
+          income: income,
+        ).time_to_fi
+
+        expect(result).to eq 1200
+      end
+    end
+  end
+end

--- a/spec/views/financial_data/_summary.html.erb_spec.rb
+++ b/spec/views/financial_data/_summary.html.erb_spec.rb
@@ -16,10 +16,19 @@ RSpec.describe "financial_data/_summary.html.erb" do
       expect(rendered).to have_text("AveIncome")
       expect(rendered).to have_text("AveExpenses")
       expect(rendered).to have_text("%FI")
+      expect(rendered).to have_text("TimeToFI")
+      expect(rendered).to have_text("Date Of FI")
       expect(rendered).to have_content(data_summary.net_worth)
       expect(rendered).to have_content(data_summary.average_income)
       expect(rendered).to have_content(data_summary.average_expenses)
       expect(rendered).to have_content("%.2f" % data_summary.percent_fi)
+      expect(rendered).to(
+        have_content(
+          "#{data_summary.time_to_fi / 12} years " \
+          "#{data_summary.time_to_fi % 12} months",
+        ),
+      )
+      expect(rendered).to have_content("years", "months")
     end
   end
 end


### PR DESCRIPTION
Why:
We would like to display the expected time to fi on the financial data
index page for users based off of the average expenses, income, and
current networth for a user.

This commit:
Introduces a FiCalculator service object to handle the calculation of
the time to fi number in months and add the required logic to calculate
and show this number to the user. Also fixed was a view bug where ave
expenses and ave income were swapped

---

before
 
<img width="840" alt="screen shot 2019-02-10 at 4 09 02 pm" src="https://user-images.githubusercontent.com/16049495/52539605-387e2180-2d4e-11e9-80e6-dcfe581260bd.png">


after

<img width="853" alt="screen shot 2019-02-10 at 4 08 48 pm" src="https://user-images.githubusercontent.com/16049495/52539607-3c11a880-2d4e-11e9-9298-02e01f94061e.png">
