### PR TITLE
Create task to create a test user

### DIFF
--- a/lib/tasks/dev.rake
+++ b/lib/tasks/dev.rake
@@ -2,11 +2,11 @@ if Rails.env.development? || Rails.env.test?
   require "factory_bot"
 
   namespace :dev do
+    include FactoryBot::Syntax::Methods
+    FactoryBot.find_definitions
+
     desc "Sample data for local development environment"
     task prime: "db:setup" do
-      include FactoryBot::Syntax::Methods
-      FactoryBot.find_definitions
-
       user = create(:user, email: "test@test.com", password: "password")
       income = 2000
       expenses = 1000
@@ -15,8 +15,56 @@ if Rails.env.development? || Rails.env.test?
         income += 10 * rand(10)
         expenses += 10 * rand(5)
         net_worth += 1000 * rand(3)
-        create(:financial_datum, user: user, month: month, year: 2018, income: income, expenses: expenses, net_worth: net_worth)
+        create(
+          :financial_datum,
+          user: user,
+          month: month,
+          year: 2018,
+          income: income,
+          expenses: expenses,
+          net_worth: net_worth
+        )
       end
+    end
+
+    desc "Create a test user with some test data"
+    task create_test_user: :environment do
+      user = User.find_or_create_by(email: "test@test.com")
+      user.password = "password"
+      user.save
+      FinancialDatum.where(user: user).destroy_all
+
+      income = 2000
+      expenses = 1000
+      net_worth = 100 * rand(100)
+      last_year_of_months.each do |month, year|
+        income += 10 * rand(10)
+        expenses += 10 * rand(5)
+        net_worth += 1000 * rand(3)
+        create(
+          :financial_datum,
+          user: user,
+          month: month,
+          year: year,
+          income: income,
+          expenses: expenses,
+          net_worth: net_worth
+        )
+      end
+    end
+  end
+
+  def last_year_of_months
+    today = Date.today
+    year = today.year - 1
+    month = today.month
+
+    (month...month + 12).map do |i|
+      month = i % 12
+      if month == 11
+        year += 1
+      end
+      month_year = [FinancialDatum::MONTHS[month], year]
     end
   end
 end


### PR DESCRIPTION
Why:
We would like to be able to create a user for feature development
without needing to run dev:prime which will drop and recreate the db.

This commit:
Adds a dev task 'dev:create_test_user' which will find or create a user
with a 'test@test.com' email and create one years worth of financial
data for them.