### PR TITLE
Introduce formatter for csv imports

### DIFF
--- a/app/models/financial_data_formatter.rb
+++ b/app/models/financial_data_formatter.rb
@@ -1,0 +1,9 @@
+class FinancialDataFormatter
+  def build(csv_row, user_id)
+      datum_as_hash = csv_row.to_h
+      datum_as_hash["user_id"] = user_id
+      datum_as_hash["month"] =
+        FinancialDatum::MONTHS[datum_as_hash["month"].to_i]
+      datum_as_hash
+  end
+end

--- a/app/models/financial_data_importer.rb
+++ b/app/models/financial_data_importer.rb
@@ -1,18 +1,16 @@
 class FinancialDataImporter
-  attr_reader :file_path, :user
+  attr_reader :file_path, :user, :formatter
 
   def initialize(file_path, user)
     @file_path = file_path
     @user = user
+    @formatter = FinancialDataFormatter.new
   end
 
   def import
     CSV.foreach(file_path, headers: true) do |row|
-      datum_as_hash = row.to_h
-      datum_as_hash["user_id"] = user.id
-      datum_as_hash["month"] =
-        FinancialDatum::MONTHS[datum_as_hash["month"].to_i]
-      datum = FinancialDatum.new(datum_as_hash)
+      formatted_datum = formatter.build(row, user.id)
+      datum = FinancialDatum.new(formatted_datum)
       datum.save
     end
   end

--- a/spec/models/financial_data_formatter_spec.rb
+++ b/spec/models/financial_data_formatter_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe FinancialDataFormatter do
+  describe "#build" do
+    it "returns a hash of the data for a FinancialDatum" do
+      month = 1
+      year = 2019
+      expenses = 12345
+      income = 1000
+      net_worth = 999999
+      headers = ["month", "year", "expenses", "income", "net_worth"]
+      fields = [month, year, expenses, income, net_worth]
+      csv_row = CSV::Row.new(headers, fields)
+      user_id = 1
+      formatter = FinancialDataFormatter.new
+      expected_result = {
+        month: :february,
+        year: year,
+        expenses: expenses,
+        income: income,
+        net_worth: net_worth,
+        user_id: user_id
+      }.stringify_keys
+
+      result = formatter.build(csv_row, user_id)
+
+      expect(result).to eq(expected_result)
+    end
+  end
+end


### PR DESCRIPTION
Why:
We would like to be about to format incoming csv file rows before
creating FinancialDatum records

This commit:
introduces a formatter class that can build up a formatted hash of
financial datum attributes from a given csv_row.